### PR TITLE
Add `cabal.project` file for cabal 1.24+ users

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,15 @@
+-- Cabal project file, for more details see
+-- http://cabal.readthedocs.io/en/latest/nix-local-build.html#configuring-builds-with-cabal-project
+
+packages:
+    -- core packages
+    src/ast
+    src/ast-ghc
+    src/ast-trf
+    src/ast-gen
+    src/ast-ppr
+    src/refactor
+    -- add-on packages
+    demo
+    src/cli
+    src/debug


### PR DESCRIPTION
This allows `cabal new-build` to find the project root and get told which
packages are available in the Git repo.

For more information, see
http://cabal.readthedocs.io/en/latest/nix-local-build.html#configuring-builds-with-cabal-project