### PR TITLE
Space leak

### DIFF
--- a/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
@@ -207,6 +207,7 @@ dependencyToPkgFlag _ _ = Nothing
 -- all package fragments separately), but it is how it works. See 'loadFlagsFromBuildInfo'.
 setupLoadFlags :: [ModuleCollectionId] -> [FilePath] 
                     -> [ModuleCollectionId] -> (DynFlags -> IO DynFlags) -> DynFlags -> IO DynFlags
+-- need to be strict here, otherwise the previous modules cannot be garbage collected
 setupLoadFlags !ids !roots !allDeps !flags dfs = applyDependencies ids allDeps . selectEnabled <$> flags dfs
   where selectEnabled = if any (\((mcId,mcRoot),rest) -> isDirectoryMC mcId && isIndependentMc mcRoot rest) (breaks (zip ids roots)) 
                           then id 

--- a/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
@@ -5,6 +5,7 @@
            , FlexibleContexts
            , TypeApplications
            , RankNTypes
+           , BangPatterns
            #-}
 -- | Collecting modules contained in a module collection (library, executable, testsuite or
 -- benchmark). Gets names, source file locations, compilation and load flags for these modules.
@@ -180,30 +181,23 @@ getMain' bi
   where ls = dropWhile (/= "-main-is") (concatMap snd (options bi))
 
 -- | Checks if the module collection created from a folder without .cabal file.
-isDirectoryMC :: ModuleCollection k -> Bool
-isDirectoryMC mc = case mc ^. mcId of DirectoryMC{} -> True; _ -> False
-
--- | Modify the dynamic flags to match the ghc-options and dependencies requested in the .cabal
--- file.
-compileInContext :: ModuleCollection k -> [ModuleCollection k] -> DynFlags -> IO DynFlags
-compileInContext mc mcs dfs
-  = (\dfs' -> applyDependencies mcs (mc ^. mcDependencies) (selectEnabled dfs'))
-       <$> (mc ^. mcFlagSetup $ dfs)
-  where selectEnabled = if isDirectoryMC mc then id else onlyUseEnabled
+isDirectoryMC :: ModuleCollectionId -> Bool
+isDirectoryMC DirectoryMC{} = True
+isDirectoryMC _ = False
 
 -- | Modify the dynamic flags to match the dependencies requested in the .cabal file.
-applyDependencies :: [ModuleCollection k] -> [ModuleCollectionId] -> DynFlags -> DynFlags
-applyDependencies mcs ids dfs
-  = dfs { GHC.packageFlags = GHC.packageFlags dfs ++ (catMaybes $ map (dependencyToPkgFlag mcs) ids) }
+applyDependencies :: [ModuleCollectionId] -> [ModuleCollectionId] -> DynFlags -> DynFlags
+applyDependencies mcs deps dfs
+  = dfs { GHC.packageFlags = GHC.packageFlags dfs ++ (catMaybes $ map (dependencyToPkgFlag mcs) deps) }
 
 -- | Only use the dependencies that are explicitely enabled. (As cabal does opposed to as ghc does.)
 onlyUseEnabled :: DynFlags -> DynFlags
 onlyUseEnabled = GHC.setGeneralFlag' GHC.Opt_HideAllPackages
 
 -- | Transform dependencies of a module collection into the package flags of the GHC API
-dependencyToPkgFlag :: [ModuleCollection k] -> ModuleCollectionId -> Maybe (GHC.PackageFlag)
+dependencyToPkgFlag :: [ModuleCollectionId] -> ModuleCollectionId -> Maybe (GHC.PackageFlag)
 dependencyToPkgFlag mcs lib@(LibraryMC pkgName)
-  = if isNothing $ find (\mc -> (mc ^. mcId) == lib) mcs
+  = if lib `notElem` mcs
       then Just $ GHC.ExposePackage pkgName (GHC.PackageArg pkgName) (GHC.ModRenaming True [])
       else Nothing
 dependencyToPkgFlag _ _ = Nothing
@@ -211,15 +205,16 @@ dependencyToPkgFlag _ _ = Nothing
 -- | Sets the configuration for loading all the modules from the whole project. Combines the
 -- configuration of all package fragments. This solution is not perfect (it would be better to load
 -- all package fragments separately), but it is how it works. See 'loadFlagsFromBuildInfo'.
-setupLoadFlags :: [ModuleCollection k] -> DynFlags -> IO DynFlags
-setupLoadFlags mcs dfs = applyDependencies mcs allDeps . selectEnabled <$> useSavedFlags dfs
-  where allDeps = mcs ^? traversal & mcDependencies & traversal
-        selectEnabled = if any (\(mc,rest) -> isDirectoryMC mc && isIndependentMc mc rest) (breaks mcs) then id else onlyUseEnabled
+setupLoadFlags :: [ModuleCollectionId] -> [FilePath] 
+                    -> [ModuleCollectionId] -> (DynFlags -> IO DynFlags) -> DynFlags -> IO DynFlags
+setupLoadFlags !ids !roots !allDeps !flags dfs = applyDependencies ids allDeps . selectEnabled <$> flags dfs
+  where selectEnabled = if any (\((mcId,mcRoot),rest) -> isDirectoryMC mcId && isIndependentMc mcRoot rest) (breaks (zip ids roots)) 
+                          then id 
+                          else onlyUseEnabled
           where breaks :: [a] -> [(a,[a])]
                 breaks [] = []
                 breaks (e:rest) = (e,rest) : map (\(x,ls) -> (x,e:ls)) (breaks rest)
-        useSavedFlags = foldl @[] (>=>) return (mcs ^? traversal & mcLoadFlagSetup)
-        isIndependentMc mc rest = not $ any (`isPrefixOf` (mc ^. mcRoot)) (map (^. mcRoot) rest)
+        isIndependentMc root rest = not $ any (`isPrefixOf` root) (map snd rest)
 
 -- | Collects the compilation options and enabled extensions from Cabal's build info representation.
 -- This setup will be used when loading all packages in the project. See 'setupLoadFlags'.

--- a/src/daemon/Language/Haskell/Tools/Daemon/Protocol.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Protocol.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric
            , OverloadedStrings
+           , DeriveAnyClass
            #-}
 -- | This module declares the messages that can be sent from the client to the
 -- daemon engine and from the engine to the client.
@@ -8,6 +9,7 @@ module Language.Haskell.Tools.Daemon.Protocol where
 import qualified Data.Aeson as A ((.=))
 import Data.Aeson hiding ((.=))
 import GHC.Generics (Generic)
+import Control.DeepSeq
 
 import FastString (unpackFS)
 import SrcLoc
@@ -104,7 +106,7 @@ data UndoRefactor = RemoveAdded { undoRemovePath :: FilePath }
                   | UndoChanges { undoChangedPath :: FilePath
                                 , undoDiff :: FileDiff
                                 }
-  deriving (Show, Generic)
+  deriving (Show, Generic, NFData)
 
 instance ToJSON UndoRefactor
 

--- a/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TemplateHaskell
            , RecordWildCards
            , FlexibleContexts
-           , BangPatterns
            #-}
 -- | Representation of the modules and packages in the daemon session.
 module Language.Haskell.Tools.Daemon.Representation where
@@ -18,14 +17,14 @@ import Language.Haskell.Tools.Refactor
 
 -- | The modules of a library, executable, test or benchmark. A package contains one or more module collection.
 data ModuleCollection k
-  = ModuleCollection { _mcId :: !ModuleCollectionId
-                     , _mcRoot :: !FilePath
-                     , _mcSourceDirs :: ![FilePath]
-                     , _mcModuleFiles :: ![(ModuleNameStr, FilePath)]
-                     , _mcModules :: !(Map.Map k ModuleRecord)
-                     , _mcFlagSetup :: !(DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for compiling the modules of this collection
-                     , _mcLoadFlagSetup :: !(DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for dependency analysis
-                     , _mcDependencies :: ![ModuleCollectionId]
+  = ModuleCollection { _mcId :: ModuleCollectionId
+                     , _mcRoot :: FilePath
+                     , _mcSourceDirs :: [FilePath]
+                     , _mcModuleFiles :: [(ModuleNameStr, FilePath)]
+                     , _mcModules :: (Map.Map k ModuleRecord)
+                     , _mcFlagSetup :: (DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for compiling the modules of this collection
+                     , _mcLoadFlagSetup :: (DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for dependency analysis
+                     , _mcDependencies :: [ModuleCollectionId]
                      }
 
 modCollToSfk :: ModuleCollection ModuleNameStr -> ModuleCollection SourceFileKey

--- a/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell
            , RecordWildCards
            , FlexibleContexts
+           , BangPatterns
            #-}
 -- | Representation of the modules and packages in the daemon session.
 module Language.Haskell.Tools.Daemon.Representation where
@@ -17,14 +18,14 @@ import Language.Haskell.Tools.Refactor
 
 -- | The modules of a library, executable, test or benchmark. A package contains one or more module collection.
 data ModuleCollection k
-  = ModuleCollection { _mcId :: ModuleCollectionId
-                     , _mcRoot :: FilePath
-                     , _mcSourceDirs :: [FilePath]
-                     , _mcModuleFiles :: [(ModuleNameStr, FilePath)]
-                     , _mcModules :: Map.Map k ModuleRecord
-                     , _mcFlagSetup :: DynFlags -> IO DynFlags -- ^ Sets up the ghc environment for compiling the modules of this collection
-                     , _mcLoadFlagSetup :: DynFlags -> IO DynFlags -- ^ Sets up the ghc environment for dependency analysis
-                     , _mcDependencies :: [ModuleCollectionId]
+  = ModuleCollection { _mcId :: !ModuleCollectionId
+                     , _mcRoot :: !FilePath
+                     , _mcSourceDirs :: ![FilePath]
+                     , _mcModuleFiles :: ![(ModuleNameStr, FilePath)]
+                     , _mcModules :: !(Map.Map k ModuleRecord)
+                     , _mcFlagSetup :: !(DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for compiling the modules of this collection
+                     , _mcLoadFlagSetup :: !(DynFlags -> IO DynFlags) -- ^ Sets up the ghc environment for dependency analysis
+                     , _mcDependencies :: ![ModuleCollectionId]
                      }
 
 modCollToSfk :: ModuleCollection ModuleNameStr -> ModuleCollection SourceFileKey

--- a/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Representation.hs
@@ -7,7 +7,7 @@ module Language.Haskell.Tools.Daemon.Representation where
 
 import Control.Reference
 import Data.Function (on)
-import Data.Map as Map
+import Data.Map.Strict as Map
 import Data.Maybe
 
 import DynFlags

--- a/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
@@ -140,7 +140,7 @@ reloadChangedModules :: (ModSummary -> IO a) -> ([ModSummary] -> IO ()) -> (ModS
                            -> DaemonSession (Either RefactorException [a])
 reloadChangedModules report loadCallback isChanged = handleErrors $ do
   reachable <- getReachableModules loadCallback isChanged
-  void $ checkEvaluatedMods report reachable
+  -- void $ checkEvaluatedMods report reachable
   mapM (reloadModule report) reachable
 
 -- | Get all modules that can be accessed from a given set of modules. Can be used to select which

--- a/src/daemon/Language/Haskell/Tools/Daemon/Update.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Update.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString.Char8 as StrictBS (unpack, readFile)
 import Data.Either (Either(..), either, rights)
 import Data.IORef (newIORef)
 import Data.List hiding (insert)
-import qualified Data.Map as Map (insert, keys, filter)
+import qualified Data.Map as Map
 import Data.Maybe
 import Data.Version (Version(..))
 import System.Directory (setCurrentDirectory, removeFile, doesDirectoryExist)
@@ -123,9 +123,9 @@ updateClient refactorings resp (PerformRefactoring refact modPath selection args
                                else liftIO $ resp $ DiffInfo (concatMap (either snd (^. _4)) changedMods)
                              isWatching <- gets (isJust . (^. watchProc))
                              when (not isWatching && not shutdown && not diffMode)
-                                 -- if watch is on, then it will automatically
-                                 -- reload changed files, otherwise we do it manually
-                               $ void $ reloadChanges (map ((^. sfkModuleName) . (^. _1)) (rights changedMods))
+                              -- if watch is on, then it will automatically
+                              -- reload changed files, otherwise we do it manually
+                              $ void $ reloadChanges (map ((^. sfkModuleName) . (^. _1)) (rights changedMods))
         applyChanges changes = do
           forM changes $ \case
             ModuleCreated n m otherM -> do

--- a/src/daemon/haskell-tools-daemon.cabal
+++ b/src/daemon/haskell-tools-daemon.cabal
@@ -81,6 +81,7 @@ library
   build-depends:       base                      >= 4.9   && < 5.0
                      , aeson                     >= 1.0  && < 1.3
                      , bytestring                >= 0.10  && < 1.0
+                     , deepseq                   >= 1.4   && < 2.0
                      , filepath                  >= 1.4   && < 2.0
                      , strict                    >= 0.3 && < 0.4
                      , containers                >= 0.5   && < 0.6


### PR DESCRIPTION
Major space leaks fixed:
 - One that kept the modules in memory every time they were reloaded, because they were referenced by the unevaluated flag settings of the new generation of modules.
 - One that kept the changed modules after a refactoring because the undo stack hadn't been evaluated.
 - And one that kept files read in the memory somehow because the write-out was not flushed.
 - Setting dynamic flags triggered additional operations that allocated a great amout of memory.