### PR TITLE
Profiling on windows now works with -fexternal-interpreter. Removed o…

### DIFF
--- a/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
@@ -179,7 +179,9 @@ clearModules mods = do
   -- clear the symbol cache for iserv
   liftIO $ purgeLookupSymbolCache env
   -- clear the global linker state
-  liftIO $ unload env (mapMaybe hm_linkable (eltsHpt hptStay))
+  dfs <- getSessionDynFlags
+  when (not $ gopt Opt_ExternalInterpreter dfs) $
+    liftIO $ unload env (mapMaybe hm_linkable (eltsHpt hptStay))
   -- clear name cache
   nameCache <- liftIO $ readIORef $ hsc_NC env
   let nameCache' = nameCache { nsNames = delModuleEnvList (nsNames nameCache) (map ms_mod mods) }

--- a/src/refactor/Language/Haskell/Tools/Refactor/Prepare.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Prepare.hs
@@ -20,7 +20,6 @@ import qualified GHC (loadModule)
 import GHC.Paths ( libdir )
 import GhcMonad
 import HscTypes
-import Linker (unload)
 import Outputable (Outputable(..), showSDocUnsafe)
 import Packages (initPackages)
 import SrcLoc
@@ -90,8 +89,6 @@ initGhcFlagsForTest = do initGhcFlags' True False
 initGhcFlags' :: Bool -> Bool -> Ghc ()
 initGhcFlags' needsCodeGen errorsSuppressed = do
   dflags <- getSessionDynFlags
-  env <- getSession
-  liftIO $ unload env [] -- clear linker state if ghc was used in the same process
   void $ setSessionDynFlags
     $ flip gopt_set Opt_KeepRawTokenStream
     $ flip gopt_set Opt_NoHsMain


### PR DESCRIPTION
…perations on linker while the option is on.

Provides a walkaround for #211